### PR TITLE
Global substitution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,34 @@ $sendGrid->send();
 
 You can add as many recipients as you want.
 
+## Substitutions & Custom Arguments
+Substitutions and custom arguments are practically the same thing, the only difference is that custom arguments are applied globally regardless of the recipient where substitutions are variable replacements that can differ per recipient.
+
+> Substitutions will always override any custom argument
+
+### Substitutions
+Substitutions are variables that can be replaced per recipient
+
+```php
+$sendGrid->addRecipient('john@doe.com', 'John Doe', [
+    ':salutation' => 'Mr',
+    ':first_name' => 'John',
+    ':last_name' => 'Doe'
+]);
+$sendGrid->addRecipient('jane@doe.com', 'Jane Doe', [
+    ':salutation' => 'Mrs',
+    ':first_name' => 'Jane',
+    ':last_name' => 'Doe'
+]);
+```
+
+### Custom Arguments
+Custom arguments are applied globally across all recipients unless a substitution has overridden it
+
+```php
+$sendGrid->addCustomArg(':year', DBDatetime::now()->Year());
+```
+
 ### Attachments
 You can add as many attachments as you want totalling up to 30 MB. The attachment must be a `File` object or a subclass of it such as itself or `Image`.
 

--- a/src/SendGrid.php
+++ b/src/SendGrid.php
@@ -83,6 +83,9 @@ class SendGrid
     /** @var bool */
     protected $sandbox = false;
 
+    /** @var ArrayList */
+    protected $customArgs;
+
     /**
      * SendGrid constructor.
      */
@@ -90,6 +93,7 @@ class SendGrid
     {
         $this->to = ArrayList::create();
         $this->attachments = ArrayList::create();
+        $this->customArgs = ArrayList::create();
         $this->sendGrid = new \SendGrid($this->getApiKey());
     }
 
@@ -154,6 +158,12 @@ class SendGrid
             $settings->setSandboxMode($sandbox);
 
             $mail->setMailSettings($settings);
+        }
+
+        if ($this->getCustomArgs()->count()) {
+            foreach ($this->getCustomArgs() as $customArg) {
+                $mail->addCustomArg($customArg->Key, $customArg->Value);
+            }
         }
 
         $mail->setTemplateId($this->getTemplateId());
@@ -580,6 +590,41 @@ class SendGrid
     public function setSandboxMode($sandbox)
     {
         $this->sandbox = $sandbox;
+
+        return $this;
+    }
+
+    /**
+     * Return the customArgs {@link ArrayList}
+     *
+     * @return ArrayList
+     */
+    public function getCustomArgs()
+    {
+        return $this->customArgs;
+    }
+
+    /**
+     * Add a global substitution that applies to all recipients unless overridden with
+     * personalization
+     *
+     * @param string $key
+     * @param string $value
+     *
+     * @throws \RuntimeException
+     *
+     * @return $this
+     */
+    public function addCustomArg($key, $value)
+    {
+        if ($this->customArgs->find('Key', $key)) {
+            throw new \RuntimeException("A customArg already exists with that key [$key]");
+        }
+
+        $this->customArgs->push(ArrayData::create([
+            'Key'   => $key,
+            'Value' => $value
+        ]));
 
         return $this;
     }

--- a/tests/SendGridTest.php
+++ b/tests/SendGridTest.php
@@ -11,8 +11,7 @@ use Vulcan\SendGrid\SendGrid;
 /**
  * Class SendGridTest
  * @package Vulcan\SendGrid\Tests
- *
- * @covers  SendGrid::
+ * @covers  \Vulcan\SendGrid\SendGrid
  */
 class SendGridTest extends FunctionalTest
 {
@@ -49,8 +48,8 @@ class SendGridTest extends FunctionalTest
     }
 
     /**
-     * @covers SendGrid::setBody()
-     * @covers SendGrid::getBody()
+     * @covers \Vulcan\SendGrid\SendGrid::setBody()
+     * @covers \Vulcan\SendGrid\SendGrid::getBody()
      */
     public function testBody()
     {
@@ -60,8 +59,8 @@ class SendGridTest extends FunctionalTest
     }
 
     /**
-     * @covers SendGrid::addRecipient()
-     * @covers SendGrid::getRecipients()
+     * @covers \Vulcan\SendGrid\SendGrid::addRecipient()
+     * @covers \Vulcan\SendGrid\SendGrid::getRecipients()
      */
     public function testRecipients()
     {
@@ -89,8 +88,8 @@ class SendGridTest extends FunctionalTest
     }
 
     /**
-     * @covers SendGrid::setScheduleTo()
-     * @covers SendGrid::getSchedule()
+     * @covers \Vulcan\SendGrid\SendGrid::setScheduleTo()
+     * @covers \Vulcan\SendGrid\SendGrid::getSchedule()
      */
     public function testScheduling()
     {
@@ -107,10 +106,11 @@ class SendGridTest extends FunctionalTest
     }
 
     /**
-     * @covers SendGrid::send()
-     * @covers SendGrid::setSandboxMode()
-     * @covers SendGrid::setTemplateId()
-     * @covers SendGrid::setFrom()
+     * @covers \Vulcan\SendGrid\SendGrid::send()
+     * @covers \Vulcan\SendGrid\SendGrid::setSandboxMode()
+     * @covers \Vulcan\SendGrid\SendGrid::setTemplateId()
+     * @covers \Vulcan\SendGrid\SendGrid::setFrom()
+     * @covers \Vulcan\SendGrid\SendGrid::addCustomArg()
      */
     public function testSend()
     {
@@ -129,7 +129,32 @@ class SendGridTest extends FunctionalTest
         $this->sendGrid->setSubject('Just testing...');
         $this->sendGrid->setBody('<p>Lorem ipsum dolor sit amet.</p>');
         $this->sendGrid->setTemplateId(getenv('SG_TEMPLATE_ID'));
+        $this->sendGrid->addCustomArg(':year', DBDatetime::now()->Year());
 
         $this->assertTrue($this->sendGrid->send());
+    }
+
+    /**
+     * @covers \Vulcan\SendGrid\SendGrid::addCustomArg()
+     * @covers \Vulcan\SendGrid\SendGrid::getCustomArgs()
+     */
+    public function testCustomArgs()
+    {
+        $this->sendGrid->addCustomArg(':name', 'Reece Alexander');
+
+        /** @var ArrayData $first */
+        $first = $this->sendGrid->getCustomArgs()->first();
+
+        $this->assertEquals([
+            'Key'   => ':name',
+            'Value' => 'Reece Alexander'
+        ], $first->toMap());
+
+        try {
+            $this->sendGrid->addCustomArg(':name', 'Reece Alexander');
+            $this->fail('You should not be able to add the same customArg key twice');
+        } catch (\Exception $e) {
+            $this->assertTrue(true);
+        }
     }
 }


### PR DESCRIPTION
Add global substitutions:

```php
$sendGrid->addCustomArg(':name', 'Reece Alexander');
```

Resolves #7 